### PR TITLE
Only monkey patch when argument is string

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-transitionend",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Just a monkeypatch for transitionend CSS animation events",
   "main": ["jquery-transitionend.js"],
   "devDependencies": {


### PR DESCRIPTION
[jQuery.on](http://api.jquery.com/on/) allows the argument to be an object.
This monkey patch would fail on such cases.
